### PR TITLE
[exports] use lib folder instead of dist folder + fix esm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -9,10 +9,10 @@
   "module": "lib/react-responsive.modern.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "require": "./dist/react-responsive.js",
-    "import": "./dist/react-responsive.modern.js",
-    "browser": "./dist/react-responsive.modern.js",
-    "umd": "./dist/react-responsive.umd.js"
+    "require": "./lib/react-responsive.js",
+    "import": "./lib/react-responsive.modern.js",
+    "browser": "./lib/react-responsive.modern.js",
+    "umd": "./lib/react-responsive.umd.js"
   },
   "repository": "git@github.com:bloczjs/react-responsive.git",
   "keywords": [

--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -15,8 +15,7 @@
       "browser": "./lib/react-responsive.modern.js",
       "umd": "./lib/react-responsive.umd.js"
     },
-    "./package.json": "./package.json",
-    "./": "./"
+    "./package.json": "./package.json"
   },
   "repository": "git@github.com:bloczjs/react-responsive.git",
   "keywords": [

--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -9,10 +9,14 @@
   "module": "lib/react-responsive.modern.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "require": "./lib/react-responsive.js",
-    "import": "./lib/react-responsive.modern.js",
-    "browser": "./lib/react-responsive.modern.js",
-    "umd": "./lib/react-responsive.umd.js"
+    ".": {
+      "require": "./lib/react-responsive.js",
+      "import": "./lib/react-responsive.modern.js",
+      "browser": "./lib/react-responsive.modern.js",
+      "umd": "./lib/react-responsive.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
   },
   "repository": "git@github.com:bloczjs/react-responsive.git",
   "keywords": [

--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "main": "lib/react-responsive.js",
   "umd:main": "lib/react-responsive.umd.js",
-  "module": "lib/react-responsive.modern.mjs",
+  "module": "lib/react-responsive.modern.js",
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "bugs": "https://github.com/bloczjs/react-responsive/issues",
   "scripts": {
-    "build": "yarn -s build:microbundle",
+    "build": "yarn -s build:microbundle && cp lib/react-responsive.modern.js lib/react-responsive.modern.mjs",
     "build:dev": "yarn -s build:microbundle --compress false",
     "build:microbundle": "microbundle --name $npm_package_name --globals react=React",
     "link:readme": "rm ../../README.md && ln -s packages/react-responsive/README.md ../..",

--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -6,12 +6,12 @@
   "sideEffects": false,
   "main": "lib/react-responsive.js",
   "umd:main": "lib/react-responsive.umd.js",
-  "module": "lib/react-responsive.modern.js",
+  "module": "lib/react-responsive.modern.mjs",
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
       "require": "./lib/react-responsive.js",
-      "import": "./lib/react-responsive.modern.js",
+      "import": "./lib/react-responsive.modern.mjs",
       "browser": "./lib/react-responsive.modern.js",
       "umd": "./lib/react-responsive.umd.js"
     },

--- a/packages/tests/src/__tests__/esm.mjs
+++ b/packages/tests/src/__tests__/esm.mjs
@@ -1,0 +1,4 @@
+import * as ReactResponsive from "@blocz/react-responsive";
+import packageJSON from "@blocz/react-responsive/package.json";
+
+console.log("Didn’t crash");

--- a/packages/tests/src/__tests__/resolver.ts
+++ b/packages/tests/src/__tests__/resolver.ts
@@ -1,0 +1,48 @@
+import { execSync } from "child_process";
+
+describe("ESM", () => {
+  it("should work in ESM context", () => {
+    expect(
+      execSync(
+        "node --experimental-json-modules ./esm.mjs",
+        {
+          cwd: __dirname,
+          encoding: "utf-8",
+        },
+      ),
+    ).toBe("Didn’t crash\n");
+  });
+});
+
+describe("built files", () => {
+  it("should contain all necessary files", () => {
+    expect(
+      require.resolve("@blocz/react-responsive"),
+    ).not.toBeNull();
+    expect(
+      require.resolve(
+        "@blocz/react-responsive/package.json",
+      ),
+    ).not.toBeNull();
+    expect(
+      require.resolve(
+        "@blocz/react-responsive/lib/react-responsive.js",
+      ),
+    ).not.toBeNull();
+    expect(
+      require.resolve(
+        "@blocz/react-responsive/lib/react-responsive.modern.js",
+      ),
+    ).not.toBeNull();
+    expect(
+      require.resolve(
+        "@blocz/react-responsive/lib/react-responsive.modern.mjs",
+      ),
+    ).not.toBeNull();
+    expect(
+      require.resolve(
+        "@blocz/react-responsive/lib/react-responsive.umd.js",
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/packages/tests/src/__tests__/resolver.ts
+++ b/packages/tests/src/__tests__/resolver.ts
@@ -1,7 +1,18 @@
 import { execSync } from "child_process";
 
-describe("ESM", () => {
-  it("should work in ESM context", () => {
+describe("Important files should be resolvable", () => {
+  it("should work in a CJS context", () => {
+    expect(
+      require.resolve("@blocz/react-responsive"),
+    ).not.toBeNull();
+    expect(
+      require.resolve(
+        "@blocz/react-responsive/package.json",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("should work in a ESM context", () => {
     expect(
       execSync(
         "node --experimental-json-modules ./esm.mjs",
@@ -16,14 +27,6 @@ describe("ESM", () => {
 
 describe("built files", () => {
   it("should contain all necessary files", () => {
-    expect(
-      require.resolve("@blocz/react-responsive"),
-    ).not.toBeNull();
-    expect(
-      require.resolve(
-        "@blocz/react-responsive/package.json",
-      ),
-    ).not.toBeNull();
     expect(
       require.resolve(
         "@blocz/react-responsive/lib/react-responsive.js",

--- a/packages/tests/tsconfig.json
+++ b/packages/tests/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,8 +17,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Fix "exports" map in the package.json:
- use `lib/` instead of `dist/` (doesn't exists)
- switch to `.mjs` for node
- include `package.json` and `./`