### PR TITLE
[global] avoid polluting the global namespace

### DIFF
--- a/packages/react-responsive/src/Match.tsx
+++ b/packages/react-responsive/src/Match.tsx
@@ -7,13 +7,9 @@ export interface MatchChildProps {
   only?: string;
 }
 
-/* eslint-disable */
-declare global {
-  namespace React {
-    interface HTMLAttributes<T> extends MatchChildProps {}
-  }
+declare module "react" {
+  interface HTMLAttributes<T> extends React.AriaAttributes, React.DOMAttributes<T>, MatchChildProps {}
 }
-/* eslint-enable */
 
 type Element = React.ReactElement<MatchChildProps & any, string | React.ComponentType<MatchChildProps & any>> | null;
 


### PR DESCRIPTION
@jnelken reached out to me because his TS wasn't warning him in his project when we was using `React` (like `React.useMemo`) without importing it.

With further research, I noticed that this was related to this library: we are polluting the global scope with a React namespace, making it available for everyone.