### PR TITLE
[react 18] mark as available

### DIFF
--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -43,6 +43,6 @@
     "microbundle": "0.13.0"
   },
   "peerDependencies": {
-    "react": "16.8.0 - 17.x.x"
+    "react": "16.8.0 - 18.x.x"
   }
 }

--- a/packages/react-responsive/src/useMediaQuery.ts
+++ b/packages/react-responsive/src/useMediaQuery.ts
@@ -1,12 +1,21 @@
 import * as React from "react";
 
+// const startTransitionFallbackForReact17AndBellow = (cb: () => void) => cb();
+// // @ts-expect-error not supported yet
+// const startTransition = React.startTransition || startTransitionFallbackForReact17AndBellow;
+
 export const useMediaQuery = (mediaQuery: string): boolean => {
   const mediaQueryList = React.useMemo(() => matchMedia(mediaQuery), [mediaQuery]);
   const [isShown, setIsShown] = React.useState<boolean>(mediaQueryList.matches);
 
   React.useLayoutEffect(() => {
     setIsShown(mediaQueryList.matches);
-    const listener = (event: MediaQueryListEvent) => setIsShown(event.matches);
+    const listener = (event: MediaQueryListEvent) => {
+      // We use startTransition as those update aren't urgent
+      // startTransition(() => {
+      setIsShown(event.matches);
+      // });
+    };
 
     // cannot use addEventListener for IE 11 and safari 13-
     mediaQueryList.addListener(listener);

--- a/packages/react-responsive/tsconfig.json
+++ b/packages/react-responsive/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // "allowSyntheticDefaultImports": true,
     "moduleResolution": "node"
   },
   "include": ["src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,7 +1653,7 @@ __metadata:
     "@types/react": ^17.0.0
     microbundle: 0.13.0
   peerDependencies:
-    react: 16.8.0 - 17.x.x
+    react: 16.8.0 - 18.x.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR mark react 18 as compatible with @blocz/react-responsive, it doesn't change any behavior