### PR TITLE
[gh action] run on node 14 16 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Those are the current versions of node:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/22725671/172257339-f1125c01-1e2d-4b79-b46a-5b8ec3ade43d.png">
