### PR TITLE
[gh action] drop node 14 and use new JSON import syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/packages/tests/src/__tests__/esm.mjs
+++ b/packages/tests/src/__tests__/esm.mjs
@@ -1,4 +1,4 @@
 import * as ReactResponsive from "@blocz/react-responsive";
-import packageJSON from "@blocz/react-responsive/package.json";
+import packageJSON from "@blocz/react-responsive/package.json" assert { type: "json" };
 
 console.log("Didn’t crash");

--- a/packages/tests/src/__tests__/resolver.ts
+++ b/packages/tests/src/__tests__/resolver.ts
@@ -14,13 +14,10 @@ describe("Important files should be resolvable", () => {
 
   it("should work in a ESM context", () => {
     expect(
-      execSync(
-        "node --experimental-json-modules ./esm.mjs",
-        {
-          cwd: __dirname,
-          encoding: "utf-8",
-        },
-      ),
+      execSync("node ./esm.mjs", {
+        cwd: __dirname,
+        encoding: "utf-8",
+      }),
     ).toBe("Didn’t crash\n");
   });
 });


### PR DESCRIPTION
`--experimental-json-modules`  no longer works now that `import json from "*.json" assert { type: "json" };` has been released. And this latter isn't available in node 14 so bye bye node 14