### PR TITLE
Add types in exports

### DIFF
--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -10,6 +10,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./lib/react-responsive.js",
       "import": "./lib/react-responsive.modern.mjs",
       "browser": "./lib/react-responsive.modern.js",


### PR DESCRIPTION
Starting in TS 4.7, when using `exports` fields, we need to also specify `types` in there (cf https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)