### PR TITLE
update node in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/tests/src/__tests__/esm.mjs
+++ b/packages/tests/src/__tests__/esm.mjs
@@ -1,4 +1,4 @@
 import * as ReactResponsive from "@blocz/react-responsive";
-import packageJSON from "@blocz/react-responsive/package.json" assert { type: "json" };
+import packageJSON from "@blocz/react-responsive/package.json" with { type: "json" };
 
 console.log("Didn’t crash");


### PR DESCRIPTION
- node 22 is the new LTS, and node 20 is in support mode
- import JSON modules with `assert` is deprecated