### PR TITLE
update react to v19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Drop support for `Math` as this is an anti pattern (leaking into the web TS globals) **BREAKING CHANGE**
 - Drop support for node 16 & 18, and add for 20 & 22
 - Update support TS version to 5.7.2 (shouldn’t impact people depending on `@blocz/react-responsive`)
+- Mark React 19 as available
 
 ## v3
 

--- a/packages/react-responsive/package.json
+++ b/packages/react-responsive/package.json
@@ -40,10 +40,10 @@
   },
   "homepage": "https://github.com/bloczjs/react-responsive#readme",
   "devDependencies": {
-    "@types/react": "^18.0.12",
+    "@types/react": "^19.0.1",
     "microbundle": "^0.15.1"
   },
   "peerDependencies": {
-    "react": "16.8.0 - 18.x.x"
+    "react": "16.8.0 - 19.x.x"
   }
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@blocz/react-responsive": "workspace:*",
     "@emotion/css": "^11.13.5",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
@@ -18,8 +18,8 @@
     "@types/jest": "^29.5.14",
     "@types/jest-environment-puppeteer": "^5.0.6",
     "@types/node": "^22.10.1",
-    "@types/react": "^18.0.12",
-    "@types/react-dom": "^18.0.5",
+    "@types/react": "^19.0.1",
+    "@types/react-dom": "^19.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-puppeteer": "^10.1.4",

--- a/packages/tests/src/index.ts
+++ b/packages/tests/src/index.ts
@@ -1,5 +1,5 @@
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import App from "./App";
 
-render(App, document.getElementById("root"));
+createRoot(document.getElementById("root")!).render(App);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,10 +1400,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@blocz/react-responsive@workspace:packages/react-responsive"
   dependencies:
-    "@types/react": "npm:^18.0.12"
+    "@types/react": "npm:^19.0.1"
     microbundle: "npm:^0.15.1"
   peerDependencies:
-    react: 16.8.0 - 18.x.x
+    react: 16.8.0 - 19.x.x
   languageName: unknown
   linkType: soft
 
@@ -3522,13 +3522,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.14
-  resolution: "@types/prop-types@npm:15.7.14"
-  checksum: 10/d0c5407b9ccc3dd5fae0ccf9b1007e7622ba5e6f1c18399b4f24dff33619d469da4b9fa918a374f19dc0d9fe6a013362aab0b844b606cfc10676efba3f5f736d
-  languageName: node
-  linkType: hard
-
 "@types/puppeteer@npm:^5.4.0":
   version: 5.4.7
   resolution: "@types/puppeteer@npm:5.4.7"
@@ -3538,22 +3531,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.0.5":
-  version: 18.3.2
-  resolution: "@types/react-dom@npm:18.3.2"
+"@types/react-dom@npm:^19.0.1":
+  version: 19.0.1
+  resolution: "@types/react-dom@npm:19.0.1"
   dependencies:
-    "@types/react": "npm:^18"
-  checksum: 10/29337fe650ec49178121a815f0c5b7f6081e63b216a29bd6f90bb5e5b0367d60a95b50a25b1848031c82458de2dfb62f78b18e72d0e6fed6f77951e64e3897d1
+    "@types/react": "npm:*"
+  checksum: 10/59d0704e445a3e0d034ef016c92dc1bbec0ba6c1af084bf6de18f0ac3abd18a632961b7fd48668c519137d0bd7bfa77a8135a66c2725d4b7f68b830be263a564
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18, @types/react@npm:^18.0.12":
-  version: 18.3.14
-  resolution: "@types/react@npm:18.3.14"
+"@types/react@npm:*, @types/react@npm:^19.0.1":
+  version: 19.0.1
+  resolution: "@types/react@npm:19.0.1"
   dependencies:
-    "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/683927b1e24293276cf62f60f1baa666b7f1053c87ec8d8c79d2d4bc105b99e0492482f801ffce7cdef9d656c11294faa423051807a500c7475f4fbd7661bd8d
+  checksum: 10/930dd4904047059c48ae64a90fc5e8078b5bac0a14c9d927917e5a07e88e4e5073ddc944cbde90a955f9f815c23b7112caea63e407bc423913073bedecb097aa
   languageName: node
   linkType: hard
 
@@ -8173,7 +8165,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -9857,15 +9849,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.1.0":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
+"react-dom@npm:^19.0.0":
+  version: 19.0.0
+  resolution: "react-dom@npm:19.0.0"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
+    scheduler: "npm:^0.25.0"
   peerDependencies:
-    react: ^18.3.1
-  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
+    react: ^19.0.0
+  checksum: 10/aa64a2f1991042f516260e8b0eca0ae777b6c8f1aa2b5ae096e80bbb6ac9b005aef2bca697969841d34f7e1819556263476bdfea36c35092e8d9aefde3de2d9a
   languageName: node
   linkType: hard
 
@@ -9930,8 +9921,8 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@types/jest-environment-puppeteer": "npm:^5.0.6"
     "@types/node": "npm:^22.10.1"
-    "@types/react": "npm:^18.0.12"
-    "@types/react-dom": "npm:^18.0.5"
+    "@types/react": "npm:^19.0.1"
+    "@types/react-dom": "npm:^19.0.1"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     jest-puppeteer: "npm:^10.1.4"
@@ -9939,19 +9930,17 @@ __metadata:
     parcel: "npm:^2.13.2"
     process: "npm:^0.11.10"
     puppeteer: "npm:^23.10.2"
-    react: "npm:^18.1.0"
-    react-dom: "npm:^18.1.0"
+    react: "npm:^19.0.0"
+    react-dom: "npm:^19.0.0"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
 
-"react@npm:^18.1.0":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
+"react@npm:^19.0.0":
+  version: 19.0.0
+  resolution: "react@npm:19.0.0"
+  checksum: 10/2490969c503f644703c88990d20e4011fa6119ddeca451e9de48f6d7ab058d670d2852a5fcd3aa3cd90a923ab2815d532637bd4a814add402ae5c0d4f129ee71
   languageName: node
   linkType: hard
 
@@ -10374,12 +10363,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
+"scheduler@npm:^0.25.0":
+  version: 0.25.0
+  resolution: "scheduler@npm:0.25.0"
+  checksum: 10/e661e38503ab29a153429a99203fefa764f28b35c079719eb5efdd2c1c1086522f6653d8ffce388209682c23891a6d1d32fa6badf53c35fb5b9cd0c55ace42de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
React 18 & 19 are about the same in term of APIs (except `render` vs `createRoot` and a few other deprecated APIs not used by `@blocz/react-responsive`. So adding support for react 19 is just allowing it + making sure it passes on it