### PR TITLE
Enable `isolatedDeclarations`

### DIFF
--- a/packages/react-responsive/src/BreakpointsContext.tsx
+++ b/packages/react-responsive/src/BreakpointsContext.tsx
@@ -10,7 +10,9 @@ const defaultBreakpoints: ExposedBreakpoints = {
   xl: [1200, Infinity, "px"], // Extra large devices (large desktops)
 };
 
-export const BreakpointsContext = React.createContext<Breakpoints>(sanitize(defaultBreakpoints));
+export const BreakpointsContext: React.Context<Breakpoints> = React.createContext<Breakpoints>(
+  sanitize(defaultBreakpoints),
+);
 
 interface BreakpointsProviderProps {
   breakpoints?: ExposedBreakpoints;

--- a/packages/react-responsive/src/Only.tsx
+++ b/packages/react-responsive/src/Only.tsx
@@ -31,5 +31,3 @@ export function Only<OtherProps = Record<string, never>>({
     children,
   );
 }
-
-Only.displayName = "Only";

--- a/packages/react-responsive/src/index.ts
+++ b/packages/react-responsive/src/index.ts
@@ -2,4 +2,4 @@ export { BreakpointsProvider, BreakpointsContext } from "./BreakpointsContext";
 export { Only } from "./Only";
 export { useBreakpoint } from "./useBreakpoint";
 export { useMediaQuery } from "./useMediaQuery";
-export { Units } from "./sanitize";
+export { type Units } from "./sanitize";

--- a/packages/react-responsive/src/useMediaQuery.ts
+++ b/packages/react-responsive/src/useMediaQuery.ts
@@ -1,9 +1,5 @@
 import * as React from "react";
 
-// const startTransitionFallbackForReact17AndBellow = (cb: () => void) => cb();
-// // @ts-expect-error not supported yet
-// const startTransition = React.startTransition || startTransitionFallbackForReact17AndBellow;
-
 export const useMediaQuery = (mediaQuery: string): boolean => {
   const mediaQueryList = React.useMemo(() => matchMedia(mediaQuery), [mediaQuery]);
   const [isShown, setIsShown] = React.useState<boolean>(mediaQueryList.matches);
@@ -11,10 +7,8 @@ export const useMediaQuery = (mediaQuery: string): boolean => {
   React.useLayoutEffect(() => {
     setIsShown(mediaQueryList.matches);
     const listener = (event: MediaQueryListEvent) => {
-      // We use startTransition as those update aren't urgent
-      // startTransition(() => {
+      // Those are important updates, so we don't want to use transitions on them
       setIsShown(event.matches);
-      // });
     };
 
     // cannot use addEventListener for IE 11 and safari 13-

--- a/packages/react-responsive/tsconfig.json
+++ b/packages/react-responsive/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "jsx": "react",
     "jsxFactory": "React.createElement",
+    "isolatedDeclarations": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
For faster TS perfs, enable `isolatedDeclarations` to ensure that we're generating the proper types on export